### PR TITLE
Add template instantiation for pcl::PointXYZRGB

### DIFF
--- a/src/fast_gicp/gicp/fast_gicp.cpp
+++ b/src/fast_gicp/gicp/fast_gicp.cpp
@@ -4,3 +4,4 @@
 template class fast_gicp::FastGICP<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::FastGICP<pcl::PointXYZI, pcl::PointXYZI>;
 template class fast_gicp::FastGICP<pcl::PointNormal, pcl::PointNormal>;
+template class fast_gicp::FastGICP<pcl::PointXYZRGB, pcl::PointXYZRGB>;

--- a/src/fast_gicp/gicp/fast_vgicp.cpp
+++ b/src/fast_gicp/gicp/fast_vgicp.cpp
@@ -4,3 +4,4 @@
 template class fast_gicp::FastVGICP<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::FastVGICP<pcl::PointXYZI, pcl::PointXYZI>;
 template class fast_gicp::FastVGICP<pcl::PointNormal, pcl::PointNormal>;
+template class fast_gicp::FastVGICP<pcl::PointXYZRGB, pcl::PointXYZRGB>;

--- a/src/fast_gicp/gicp/fast_vgicp_cuda.cpp
+++ b/src/fast_gicp/gicp/fast_vgicp_cuda.cpp
@@ -4,3 +4,4 @@
 template class fast_gicp::FastVGICPCuda<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::FastVGICPCuda<pcl::PointXYZI, pcl::PointXYZI>;
 template class fast_gicp::FastVGICPCuda<pcl::PointNormal, pcl::PointNormal>;
+template class fast_gicp::FastVGICPCuda<pcl::PointXYZRGB, pcl::PointXYZRGB>;

--- a/src/fast_gicp/gicp/lsq_registration.cpp
+++ b/src/fast_gicp/gicp/lsq_registration.cpp
@@ -4,3 +4,4 @@
 template class fast_gicp::LsqRegistration<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::LsqRegistration<pcl::PointXYZI, pcl::PointXYZI>;
 template class fast_gicp::LsqRegistration<pcl::PointNormal, pcl::PointNormal>;
+template class fast_gicp::LsqRegistration<pcl::PointXYZRGB, pcl::PointXYZRGB>;


### PR DESCRIPTION
Hello @koide3,

In this PR, I have incorporate template instantiation pcl::PointXYZRGB so that the fast_gicp library support pointcloud which are colored as well. I have tested it and it works correctly. You can merge this PR if this makes sense to you.

Thanks.