### PR TITLE
use system pybind11 package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "thirdparty/nvbio"]
 	path = thirdparty/nvbio
 	url = https://github.com/NVlabs/nvbio.git
-[submodule "thirdparty/pybind11"]
-	path = thirdparty/pybind11
-	url = https://github.com/pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,10 @@ if(BUILD_PYTHON_BINDINGS)
   target_link_libraries(pygicp PRIVATE
     fast_gicp
   )
+  set_target_properties(pygicp PROPERTIES
+    INSTALL_RPATH "$ORIGIN/"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
 endif()
 
 ### CUDA ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 
 ### Python bindings ###
 if(BUILD_PYTHON_BINDINGS)
-  add_subdirectory(thirdparty/pybind11)
+  find_package(pybind11 CONFIG)
   pybind11_add_module(pygicp
     src/python/main.cpp
   )

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ class CMakeBuild(build_ext):
             "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm,
             # "-DBUILD_VGICP_CUDA=ON",
             "-DBUILD_PYTHON_BINDINGS=ON",
+            "-DBUILD_apps=OFF",
         ]
         build_args = []
 


### PR DESCRIPTION
This fixes the compilation error:
```
error: invalid use of incomplete type ‘PyFrameObject’ {aka ‘struct _frame’}
error: expected primary-expression before ‘>’ token
error: expected primary-expression before ‘)’ token
```
