### PR TITLE
Install apps if building with ament_cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,4 +191,9 @@ elseif (ament_cmake_FOUND)
       DIRECTORY "include/"
       DESTINATION include
     )
+
+  if (BUILD_apps)
+    install(TARGETS  gicp_align gicp_kitti
+       DESTINATION lib/${PROJECT_NAME})
+  endif()
 endif()


### PR DESCRIPTION
I realized that I could not run the executables directly from the terminal when using ros2. With ament_cmake, the targets to be executed need to be installed. After this change, the examples can be run as 

```
ros2 run fast_gicp gicp_align 251370668.pcd 251371071.pcd
```